### PR TITLE
fix(#1): add check for -1 ping and send alternate message

### DIFF
--- a/src/commands/testing/ping.js
+++ b/src/commands/testing/ping.js
@@ -19,7 +19,7 @@ module.exports = {
 			clientPing = "N/A"; // or handle the error as appropriate
 		}
 
-		const newMessage = `API Latency: ${APILatency}\nClient Ping: ${clientPing}`;
+		const newMessage = `API Latency: ${(APILatency!==-1)? APILatency: 'Still establishing a connection! Please wait for some time before running the command!'}\nClient Ping: ${clientPing}`;
 
 		await interaction.editReply({
 			content: newMessage,
@@ -28,7 +28,7 @@ module.exports = {
 	legacyExecute(message, args, client) {
 		const APILatency = client.ws.ping;
 		message.reply({
-			content: `APILatency: ${APILatency}\nClient Ping: Client ping is only available for slash commands! Run /ping to see client ping.`,
+			content: `APILatency: ${(APILatency!==-1)? APILatency: 'Still establishing a connection! Please wait for some time before running the command!'}\nClient Ping: Client ping is only available for slash commands! Run /ping to see client ping.`,
 		});
 	},
 };


### PR DESCRIPTION
### Description

The websocket class used to get the API Latency ping has a default value of -1 before the first heartbeat is sent after connection establishes. A property ```lastPingTimestamp``` stores the timestamp for the last heartbeat signal, which is default if no handshake has been done yet. This is why the issue resolves itself after sometime.

```javascript
this._ws.on(WSWebSocketShardEvents.HeartbeatComplete, ({ heartbeatAt, latency, shardId }) => {
      this.debug([`Heartbeat acknowledged, latency of ${latency}ms.`], shardId);
      const shard = this.shards.get(shardId);
      shard.lastPingTimestamp = heartbeatAt;
      shard.ping = latency;
});
```
(Source: discord.js docs)

### Change made:
I put a check for value -1 of API Latency and added a message correspondingly, for both slash command and legacy prefix command.